### PR TITLE
Added a process trigger to ensure sigint killed the process

### DIFF
--- a/src/serverEntry.js
+++ b/src/serverEntry.js
@@ -10,6 +10,10 @@ require('@babel/register')();
 
 const serverMain = require('./server').default;
 
+// Ensure we can ctrl+c the process
+process.on('SIGINT', function() {
+  process.exit(1);
+});
 
 // Call the server-side main function.
 serverMain(process.argv);


### PR DESCRIPTION
I think in some environments you don't need this. I'm using the docker image `node:12.8.0-alpine` environment, and it needs it.